### PR TITLE
F#9 gauge bias setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,13 @@ target_link_libraries(${standalone_exec_name}
   ${library_name}
 )
 
+add_executable(gauge_bias_tester
+  test/test_gauge_bias.cpp
+)
+target_link_libraries(gauge_bias_tester
+  ${library_name}
+)
+
 
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ find_package(catkin REQUIRED COMPONENTS
   std_srvs
   std_msgs
   geometry_msgs
-  cmake_modules
 )
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)

--- a/include/ati_sensor/ft_sensor.h
+++ b/include/ati_sensor/ft_sensor.h
@@ -57,6 +57,15 @@ public:
   FTSensor();
   ~FTSensor();
   
+  enum settings_error_t
+  {
+    NO_SETTINGS_ERROR,
+    SETTINGS_REQUEST_ERROR,
+    CALIB_PARSE_ERROR,
+    GAUGE_PARSE_ERROR,
+    RDTRATE_PARSE_ERROR
+  };
+  
   // Initialization, reading parameters from XML files, etc..
   bool init(std::string ip, int calibration_index = ati::current_calibration,
             uint16_t cmd = ati::command_s::REALTIME, int sample_count = -1);
@@ -100,6 +109,7 @@ public:
   void setTimeout(float sec);
   bool isInitialized();
   bool getCalibrationData();
+  settings_error_t getSettings();
   bool setRDTOutputRate(unsigned int rate);
   std::vector<int> getGaugeBias();
   bool setGaugeBias(unsigned int gauge_idx, int gauge_bias);

--- a/include/ati_sensor/ft_sensor.h
+++ b/include/ati_sensor/ft_sensor.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <sstream>
+#include <map>
+#include <vector>
 
 #define MAX_XML_SIZE 35535
 #define RDT_RECORD_SIZE 36
@@ -99,6 +101,10 @@ public:
   bool isInitialized();
   bool getCalibrationData();
   bool setRDTOutputRate(unsigned int rate);
+  bool setGaugeBias(unsigned int gauge_idx, int gauge_bias);
+  bool setGaugeBias(std::map<unsigned int, int> &gauge_map);
+  bool setGaugeBias(std::vector<int> &gauge_vect);
+
 protected:
   // Socket info
   bool startRealTimeStreaming(uint32_t sample_count=1);
@@ -118,6 +124,7 @@ protected:
   bool sendCommand();
   bool sendCommand(uint16_t cmd);
   bool getResponse();
+  bool sendTCPrequest(std::string &request_cmd);
   void doComm();
   std::string ip;
   uint16_t port;

--- a/include/ati_sensor/ft_sensor.h
+++ b/include/ati_sensor/ft_sensor.h
@@ -101,6 +101,7 @@ public:
   bool isInitialized();
   bool getCalibrationData();
   bool setRDTOutputRate(unsigned int rate);
+  std::vector<int> getGaugeBias();
   bool setGaugeBias(unsigned int gauge_idx, int gauge_bias);
   bool setGaugeBias(std::map<unsigned int, int> &gauge_map);
   bool setGaugeBias(std::vector<int> &gauge_vect);
@@ -130,6 +131,7 @@ protected:
   uint16_t port;
   int calibration_index;
   int rdt_rate_;
+  int *setbias_;
   int socketHandle_;
   int socketHTTPHandle_;  
   struct sockaddr_in addr_; 

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>libxml2</build_depend>
-  <build_depend>cmake_modules</build_depend>
   
   <run_depend>roscpp</run_depend>
   <run_depend>libxml2</run_depend>

--- a/test/test_gauge_bias.cpp
+++ b/test/test_gauge_bias.cpp
@@ -1,0 +1,67 @@
+#include <string>
+#include <stdio.h> 
+#include <ctime>
+#include <iostream>
+#include <iomanip>
+// FTSensor class definition
+#include "ati_sensor/ft_sensor.h"
+
+using namespace std;
+
+int main(int argc, char **argv) 
+{
+  uint32_t cnt(0),n(100);
+  uint32_t rdt(0),ft(0),rdt_old(0),ft_old(0);
+  clock_t t(0);
+  string ip="192.168.100.103";
+  // Read ip if given
+  if (argc >1)
+  {
+    ip = argv[1];
+  }
+
+  // The sensor object
+  cout << "Creating sensor" << endl;
+  ati::FTSensor ftsensor;
+  
+  cout << "Initializing sensor" << endl;
+  ftsensor.init(ip);
+
+  cout << "Set bias (reset) and read gauge bias values" << endl;
+  ftsensor.setBias();
+  ftsensor.getCalibrationData();
+  std::vector<int> gauge_bias = ftsensor.getGaugeBias();
+  if (gauge_bias.size()!=6)
+  {
+    cout << "Get gauge bias failed, size of vector read back is " << gauge_bias.size() << endl;
+    return -1;
+  }
+  cout << "Gauge bias values after biasing : " << gauge_bias[0] <<", "
+                                        << gauge_bias[1] <<", "
+                                        << gauge_bias[2] <<", "
+                                        << gauge_bias[3] <<", "
+                                        << gauge_bias[4] <<", "
+                                        << gauge_bias[5] <<", " <<std::endl;
+  
+  cout << "Set gauge bias to specific values and read them back" << endl;
+  gauge_bias.at(0) = 10;
+  gauge_bias.at(1) = -1;
+  gauge_bias.at(2) = 11;
+  gauge_bias.at(3) = -2;
+  gauge_bias.at(4) = 12;
+  gauge_bias.at(5) = -3;
+  if(ftsensor.setGaugeBias(gauge_bias))
+  {
+    ftsensor.getCalibrationData();
+    std::vector<int> gauge_bias_new = ftsensor.getGaugeBias();
+    cout << "Gauge bias values are : " << gauge_bias_new[0] <<" (" << gauge_bias[0] <<" was set), "
+                                          << gauge_bias_new[1] <<" (" << gauge_bias[1] <<" was set), "
+                                          << gauge_bias_new[2] <<" (" << gauge_bias[2] <<" was set), "
+                                          << gauge_bias_new[3] <<" (" << gauge_bias[3] <<" was set), "
+                                          << gauge_bias_new[4] <<" (" << gauge_bias[4] <<" was set), "
+                                          << gauge_bias_new[5] <<" (" << gauge_bias[5] <<" was set), " <<std::endl;
+  }
+
+
+  return 0;
+}

--- a/test/test_gauge_bias.cpp
+++ b/test/test_gauge_bias.cpp
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
 
   cout << "Set bias (reset) and read gauge bias values" << endl;
   ftsensor.setBias();
-  ftsensor.getCalibrationData();
   std::vector<int> gauge_bias = ftsensor.getGaugeBias();
   if (gauge_bias.size()!=6)
   {
@@ -52,7 +51,6 @@ int main(int argc, char **argv)
   gauge_bias.at(5) = -3;
   if(ftsensor.setGaugeBias(gauge_bias))
   {
-    ftsensor.getCalibrationData();
     std::vector<int> gauge_bias_new = ftsensor.getGaugeBias();
     cout << "Gauge bias values are : " << gauge_bias_new[0] <<" (" << gauge_bias[0] <<" was set), "
                                           << gauge_bias_new[1] <<" (" << gauge_bias[1] <<" was set), "


### PR DESCRIPTION
to solve #9 
* I first added a way to set the Bias, hence refactoring the send function to provide more possibilities and be re-usable
* Then in order to create a manual test, I also added a getsetting function, used by default currently at start to retrieve the counts per force and the RDT rate. Now can also retrieve the current gauge bias.
* Finally added a manual test that calls bias, read the new biased value, then sets a manual bias, and reads it back for comparison. 

the test should look like this 
```
rosrun ati_sensor gauge_bias_tester 192.168.10.100
Creating sensor
Initializing sensor
Initializing ft sensor (gnulinux)
Start realtime streaming with 1 samples
Using current calibration
Sucessfully retrieved counts per force : 1000000
Sucessfully retrieved counts per torque : 1000000
Set bias (reset) and read gauge bias values
Using current calibration
Gauge bias values after biasing : -18343, -1227, 10589, 5600, 8657, -5097,
Set gauge bias to specific values and read them back
Using current calibration
Gauge bias values are : 10 (10 was set), -1 (-1 was set), 11 (11 was set), -2 (-2 was set), 12 (12 was set), -3 (-3 was set),
Sensor shutdown sucessfully
```

was tested on a NON-rtnet system and without xenomai obviously.

before merging, tested are required on such a system