### PR TITLE
Follow-up of #13 on failure at init

### DIFF
--- a/include/ati_sensor/ft_sensor.h
+++ b/include/ati_sensor/ft_sensor.h
@@ -103,6 +103,9 @@ public:
   // Write the ip of the sensor
   const std::string getIP(){return this->ip;}
   const uint16_t getPort(){return this->port;}
+  std::string message_header(){std::stringstream ss;
+                               ss << "[ft_sensor " <<  this->ip << ":" <<  this->port << "] ";
+                               return ss.str();}
   const int getRDTRate(){return this->rdt_rate_;}
   // Set the zero of the sensor	
   void setBias();

--- a/src/ft_sensor.cpp
+++ b/src/ft_sensor.cpp
@@ -159,8 +159,8 @@ FTSensor::FTSensor()
 FTSensor::~FTSensor()
 {
   stopStreaming();
-  if( 0 == closeSockets())
-      std::cout << message_header() << "Sensor shutdown sucessfully" << std::endl;
+  if(!closeSockets())
+    std::cerr << message_header() << "Sensor did not shutdown correctly" << std::endl;
   delete setbias_;
 }
 
@@ -320,12 +320,12 @@ void FTSensor::openSocket(int& handle,const std::string ip,const uint16_t port,c
 }
 bool FTSensor::closeSockets()
 {
-  return closeSocket(socketHandle_) > 0 && closeSocket(socketHTTPHandle_) > 0;
+  return closeSocket(socketHandle_) == 0 && closeSocket(socketHTTPHandle_) == 0;
 }
 int FTSensor::closeSocket(const int& handle)
 {
-  if(handle < 0 )
-      return true;
+  if(handle < 0)
+    return 0;  // closing a non-open socket is considered successful
   return rt_dev_close(handle);
 }
 


### PR DESCRIPTION
Modified failure detection to stop at first major error and improved error messages

As discussed in #13 
* failure occurs earliest possible
* no API change
* muting some info (but kept xenomai message to know it is really running in xenomai mode)

Not all failure case could be tested, don't know how to produce them. But the main fail described in #13 looks like this now 
```
process[rh/ft_sensor-1]: started with pid [350]
[ INFO] [1508921479.215189932]: ATISensor IP : 192.168.10.100
[ INFO] [1508921479.215274299]: ATISensor frame : /ati_link
Could not connect to 192.168.10.100:80       => is in normal red
openSockets error: failed to connect to socket   => is bold red
Error during initialization, FT sensor NOT started   => is bold red
Sensor shutdown sucessfully
[FATAL] [1508921482.279232529]: Failed with error : FT sensor could not initialize  => is normal red coming from the node handling the init fail.
```